### PR TITLE
Add contact us text and email option

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -66,6 +66,9 @@
                       <a class="nav-link" href="#mentors">Mentors</a>
                   </li>
                   <li class="nav-item">
+                      <a class="nav-link" href="#contact">Contact Us</a>
+                  </li>
+                  <li class="nav-item">
                       <a class="nav-link" href="{{ action('PageController@showApplicationForm') }}">Apply</a>
                   </li>                
                   <li class="nav-item">
@@ -258,7 +261,7 @@
     </section>
 
   <footer>
-    <div class="container">
+    <div id="contact" class="container">
       <div class="row">
         <div class="col-6 text-right offset-6">
           <b>Contact Us!</b>
@@ -266,7 +269,7 @@
         <div class="col-6 text-right offset-6">
           <a href="https://www.facebook.com/launchpadcs/" class="footer_link"><i class="fa fa-facebook-official fa-2x" aria-hidden="true"></i></a>
           &nbsp;
-          <a href="#" class="footer_link"><i class="fa fa-twitter-square fa-2x" aria-hidden="true"></i></a>
+          <a href="https://www.instagram.com/launchpadpurdue/" class="footer_link"><i class="fa fa-instagram fa-2x" aria-hidden="true"></i></a>
           &nbsp;
           <a href="mailto:launchpadpurdue@gmail.com" class="footer_link"><i class="fa fa-envelope-square fa-2x" aria-hidden="true"></i></a>
         </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -261,9 +261,14 @@
     <div class="container">
       <div class="row">
         <div class="col-6 text-right offset-6">
+          <b>Contact Us!</b>
+        </div>
+        <div class="col-6 text-right offset-6">
           <a href="https://www.facebook.com/launchpadcs/" class="footer_link"><i class="fa fa-facebook-official fa-2x" aria-hidden="true"></i></a>
           &nbsp;
           <a href="#" class="footer_link"><i class="fa fa-twitter-square fa-2x" aria-hidden="true"></i></a>
+          &nbsp;
+          <a href="mailto:launchpadpurdue@gmail.com" class="footer_link"><i class="fa fa-envelope-square fa-2x" aria-hidden="true"></i></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22565214/44375475-e0aede00-a4c1-11e8-97f0-3622ba3f6573.png)
Added "Contact Us!" text as well as email icon.

![image](https://user-images.githubusercontent.com/22565214/44375566-5450eb00-a4c2-11e8-925a-e5269542f27a.png)
Clicking the email icon opens up an email to the LaunchPad gmail.